### PR TITLE
Use MySQL client in login form

### DIFF
--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Configuration;
-using System.Data.SqlClient;
+using MySql.Data.MySqlClient;
 using System.Windows.Forms;
 
 namespace Ejercicio1
@@ -49,7 +49,7 @@ namespace Ejercicio1
             string password = txtPassword.Text;
             string connectionString = ConfigurationManager.ConnectionStrings["DefaultConnection"]?.ConnectionString;
 
-            using (SqlConnection connection = new SqlConnection(connectionString))
+            using (MySqlConnection connection = new MySqlConnection(connectionString))
             {
                 // TODO: validar credenciales utilizando la cadena de conexión
                 connection.Open();


### PR DESCRIPTION
## Summary
- replace SqlClient with MySqlClient in `LoginForm`

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9afe7d10832591df5eaa1f1f5ac5