### PR TITLE
Use RestauranteDb connection string

### DIFF
--- a/LoginForm.cs
+++ b/LoginForm.cs
@@ -47,7 +47,7 @@ namespace Ejercicio1
         {
             string usuario = txtUsuario.Text;
             string password = txtPassword.Text;
-            string connectionString = ConfigurationManager.ConnectionStrings["DefaultConnection"]?.ConnectionString;
+            string connectionString = ConfigurationManager.ConnectionStrings["RestauranteDb"]?.ConnectionString;
 
             using (SqlConnection connection = new SqlConnection(connectionString))
             {


### PR DESCRIPTION
## Summary
- Ensure login uses RestauranteDb connection string

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b0038e0832584b65769671a34bf